### PR TITLE
Fix import paths

### DIFF
--- a/example_fsevents_test.go
+++ b/example_fsevents_test.go
@@ -9,7 +9,7 @@ package notify_test
 import (
 	"log"
 
-	"github.com/rjeczalik/notify"
+	"github.com/zillode/notify"
 )
 
 // This example shows how to use FSEvents-specifc event values.

--- a/example_inotify_test.go
+++ b/example_inotify_test.go
@@ -10,7 +10,7 @@ import (
 	"log"
 	"syscall"
 
-	"github.com/rjeczalik/notify"
+	"github.com/zillode/notify"
 )
 
 // This example shows how to watch changes made on file-system by text editor

--- a/example_readdcw_test.go
+++ b/example_readdcw_test.go
@@ -9,7 +9,7 @@ package notify_test
 import (
 	"log"
 
-	"github.com/rjeczalik/notify"
+	"github.com/zillode/notify"
 )
 
 // This example shows how to watch directory-name changes in the working directory subtree.

--- a/example_test.go
+++ b/example_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/rjeczalik/notify"
+	"github.com/zillode/notify"
 )
 
 // This is a basic example showing how to work with notify.Watch function.


### PR DESCRIPTION
This is necessary in order for godep to be able to properly treat this
forked project. Also, the tests don't pass without this change.