### PR TITLE
include node name in error when traversing fails

### DIFF
--- a/node.go
+++ b/node.go
@@ -70,7 +70,7 @@ Traverse:
 		case errSkip:
 			continue Traverse
 		default:
-			return err
+			return fmt.Errorf("error while traversing %q: %v", nd.Name, err)
 		}
 		// TODO(rjeczalik): tolerate open failures - add failed names to
 		// AddDirError and notify users which names are not added to the tree.


### PR DESCRIPTION
I use Syncthing to recursively watch my whole `$HOME`.
It fails on the FUSE mount `.gvfs` and this took me *muuuch* to long to figure out.
With this change it is much more easy to debug such issues.