### PR TITLE
add capability to ignore paths

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -60,8 +60,9 @@ var defaultTree = newTree()
 // mind this limitation while setting recursive watchpoints for your application,
 // e.g. use persistant paths like %userprofile% or watch additionally parent
 // directory of a recursive watchpoint in order to receive delete events for it.
-func Watch(path string, c chan<- EventInfo, events ...Event) error {
-	return defaultTree.Watch(path, c, events...)
+func Watch(path string, c chan<- EventInfo, ignoreTest func(string) bool,
+	events ...Event) error {
+	return defaultTree.Watch(path, c, ignoreTest, events...)
 }
 
 // Stop removes all watchpoints registered for c. All underlying watches are

--- a/notify.go
+++ b/notify.go
@@ -21,14 +21,14 @@ package notify
 
 var defaultTree = newTree()
 
-// ignoreTest determines whether path should be ignored (return value true).
-var ignoreTest = func(path string) bool {
+// doNotWatch determines whether path should be ignored (return value true).
+var doNotWatch = func(path string) bool {
 	return false
 }
 
-// Exported function to set ignoreTest
-func SetIgnoreTest(newIgnoreTest func(string) bool) {
-	ignoreTest = newIgnoreTest
+// Exported function to set doNotWatch
+func SetDoNotWatch(newIgnoreTest func(string) bool) {
+	doNotWatch = newIgnoreTest
 }
 
 // Watch sets up a watchpoint on path listening for events given by the events
@@ -71,7 +71,7 @@ func SetIgnoreTest(newIgnoreTest func(string) bool) {
 // e.g. use persistant paths like %userprofile% or watch additionally parent
 // directory of a recursive watchpoint in order to receive delete events for it.
 func Watch(path string, c chan<- EventInfo, events ...Event) error {
-	return defaultTree.Watch(path, c, ignoreTest, events...)
+	return defaultTree.Watch(path, c, doNotWatch, events...)
 }
 
 // Stop removes all watchpoints registered for c. All underlying watches are

--- a/notify.go
+++ b/notify.go
@@ -21,6 +21,16 @@ package notify
 
 var defaultTree = newTree()
 
+// ignoreTest determines whether path should be ignored (return value true).
+var ignoreTest = func(path string) bool {
+	return false
+}
+
+// Exported function to set ignoreTest
+func SetIgnoreTest(newIgnoreTest func(string) bool) {
+	ignoreTest = newIgnoreTest
+}
+
 // Watch sets up a watchpoint on path listening for events given by the events
 // argument.
 //
@@ -60,8 +70,7 @@ var defaultTree = newTree()
 // mind this limitation while setting recursive watchpoints for your application,
 // e.g. use persistant paths like %userprofile% or watch additionally parent
 // directory of a recursive watchpoint in order to receive delete events for it.
-func Watch(path string, c chan<- EventInfo, ignoreTest func(string) bool,
-	events ...Event) error {
+func Watch(path string, c chan<- EventInfo, events ...Event) error {
 	return defaultTree.Watch(path, c, ignoreTest, events...)
 }
 

--- a/tree.go
+++ b/tree.go
@@ -7,7 +7,7 @@ package notify
 const buffer = 128
 
 type tree interface {
-	Watch(string, chan<- EventInfo, ...Event) error
+	Watch(string, chan<- EventInfo, func(string) bool, ...Event) error
 	Stop(chan<- EventInfo)
 	Close() error
 }

--- a/tree_recursive.go
+++ b/tree_recursive.go
@@ -154,7 +154,7 @@ func (t *recursiveTree) dispatch() {
 
 // Watch TODO(rjeczalik)
 func (t *recursiveTree) Watch(path string, c chan<- EventInfo,
-	ignoreTest func(string) bool, events ...Event) error {
+	doNotWatch func(string) bool, events ...Event) error {
 	if c == nil {
 		panic("notify: Watch using nil channel")
 	}

--- a/tree_recursive.go
+++ b/tree_recursive.go
@@ -153,7 +153,8 @@ func (t *recursiveTree) dispatch() {
 }
 
 // Watch TODO(rjeczalik)
-func (t *recursiveTree) Watch(path string, c chan<- EventInfo, events ...Event) error {
+func (t *recursiveTree) Watch(path string, c chan<- EventInfo,
+	ignoreTest func(string) bool, events ...Event) error {
 	if c == nil {
 		panic("notify: Watch using nil channel")
 	}


### PR DESCRIPTION
The reason for this PR is that currently installing watches recursively on a directory is aborted when any error is encountered. This PR adds the possibility to ignore errors based on their path. To achieve this a function that determines whether a path should be ignored or not has to be passed as argument to the Watch function. This function has to accepts a path as a string as argument and returns a bool (true for should be ignored).

Possible caveats:
- Only parts of the package that were used in my scenario or that were necessary for compilation were modified. There are possibly more modifications necessary to adapt the package as a whole to the introduced change to the high level Watch function.
- The PR was only tested in conjunction with synchting-inotify (syncthing/syncthing-inotify#103) on linux and ext4 FS. All changes seem to be on a higher level than OS/FS, so it should work also on other OS/FS, but the point above may be a problem.