### PR TITLE
Fix ignoring mechanism: Remove SetDoNotWatch and introduce WatchWithIgnore

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -21,16 +21,6 @@ package notify
 
 var defaultTree = newTree()
 
-// doNotWatch determines whether path should be ignored (return value true).
-var doNotWatch = func(path string) bool {
-	return false
-}
-
-// Exported function to set doNotWatch
-func SetDoNotWatch(newIgnoreTest func(string) bool) {
-	doNotWatch = newIgnoreTest
-}
-
 // Watch sets up a watchpoint on path listening for events given by the events
 // argument.
 //
@@ -71,6 +61,15 @@ func SetDoNotWatch(newIgnoreTest func(string) bool) {
 // e.g. use persistant paths like %userprofile% or watch additionally parent
 // directory of a recursive watchpoint in order to receive delete events for it.
 func Watch(path string, c chan<- EventInfo, events ...Event) error {
+	return defaultTree.Watch(path, c, nil, events...)
+}
+
+// This function works the same way as Watch. In addition it does not watch
+// files or directories based on the return value of the argument function
+// doNotWatch. Given a path as argument doNotWatch should return true if the
+// file or directory should not be watched.
+func WatchWithFilter(path string, c chan<- EventInfo,
+	doNotWatch func(string) bool, events ...Event) error {
 	return defaultTree.Watch(path, c, doNotWatch, events...)
 }
 


### PR DESCRIPTION
This is basically rjeczalik/notify#107 (no reaction there, so it needs to be introduced here) and the discussion happened in #3.
The previous implementation is as far as I understand by now bad as in it only worked because of the specific implementation in syncthing-inotify but could otherwise fail completely.
For backwards compatibility `Watch` still works the same and `WatchWithIgnoring` was introduced, which takes as an additional argument the function that was previously passed to `SetDoNotWatch`.

This change is not compatible with the current syncthing-inotify implementation. Once this is considered good to merge I will create an accompanying PR for it.